### PR TITLE
feat(option): add a exportType=values to generate constants for CSS class names with values (instead of just definitions)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+	"useTabs": false,
+	"tabWidth": 2,
+	"arrowParens": "avoid",
+	"trailingComma": "none",
+	"singleQuote": false,
+	"printWidth": 80,
+	"jsxSingleQuote": false,
+	"semi": true,
+	"bracketSpacing": true,
+	"endOfLine": "lf"
+}

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The export type to use when generating type definitions.
 
 #### `named`
 
-Given the following LESS:
+Given the following LESS (text.less):
 
 ```less
 .text {
@@ -145,16 +145,16 @@ Given the following LESS:
 }
 ```
 
-The following type definitions will be generated:
+The following type definitions (text.less.d.ts) will be generated:
 
 ```typescript
 export const text: string;
 export const textHighlighted: string;
 ```
 
-#### `default`
+#### `values`
 
-Given the following LESS:
+Given the following LESS (text.less):
 
 ```less
 .text {
@@ -166,7 +166,59 @@ Given the following LESS:
 }
 ```
 
-The following type definitions will be generated:
+The following text.const.ts file will be generated:
+
+```typescript
+export const text = "text";
+export const textHighlighted = "text-highlighted";
+```
+
+In this mode, the tool is used to create .const.ts files instead of .d.ts files. This is the most optimal for compilation, because it allows to not process .less files with bundler thus significantly reducing compilation time for big projects.
+
+Having constants in .const.ts instead of .less.d.ts gives some additional comfort on opening source files, because we have different file extensions.
+
+1. Setup generation of .constant.ts and .css files .less on save.
+
+For VSCode, use emeraldwalk.runonsave plugin.
+
+Add these settings to .vscode/settings.json:
+
+```json
+	"emeraldwalk.runonsave": {
+		"commands": [
+			{
+				"match": "\\.less$",
+				"cmd": "lessc -x --js src/index.less build/index.css && tlm ${file} -e values"
+			}
+		]
+	},
+```
+
+2. Change imports of constants:
+
+```typescript
+import * as style from "./text.const";
+```
+
+3. Remove all imports of .less files from .tsx files
+
+4. Remove .less file handling from bundler. In case of Webpack, remove the plugin chain of .less processing: less-loader (which compiles Less to CSS), css-loader (which translates CSS into CommonJS) and MiniCssExtractPlugin.loader (which creates style nodes from JS strings).
+
+#### `default`
+
+Given the following LESS (text.less):
+
+```less
+.text {
+  color: blue;
+
+  &-highlighted {
+    color: yellow;
+  }
+}
+```
+
+The following type definitions (text.less.d.ts) will be generated:
 
 ```typescript
 export interface Styles {

--- a/__tests__/core/write-file.test.ts
+++ b/__tests__/core/write-file.test.ts
@@ -12,7 +12,7 @@ describe("writeFile", () => {
 
   test("writes the corresponding type definitions for a file and logs", async () => {
     const testFile = `${__dirname}/../style.less`;
-    const typesFile = getTypeDefinitionPath(testFile);
+    const typesFile = getTypeDefinitionPath(testFile, "default");
 
     await writeFile(testFile, {
       watch: false,

--- a/__tests__/less/file-to-class-names.test.ts
+++ b/__tests__/less/file-to-class-names.test.ts
@@ -4,7 +4,11 @@ describe("fileToClassNames", () => {
   test("it converts a file path to an array of class names (default camel cased)", async () => {
     const result = await fileToClassNames(`${__dirname}/../complex.less`);
 
-    expect(result).toEqual(["someStyles", "nestedClass", "nestedAnother"]);
+    expect(result).toEqual([
+      { value: "someStyles", valueOriginal: "some-styles" },
+      { value: "nestedClass", valueOriginal: "nested-class" },
+      { value: "nestedAnother", valueOriginal: "nested-another" }
+    ]);
   });
 
   describe("nameFormat", () => {
@@ -13,7 +17,11 @@ describe("fileToClassNames", () => {
         nameFormat: "kebab"
       });
 
-      expect(result).toEqual(["some-styles", "nested-class", "nested-another"]);
+      expect(result).toEqual([
+        { value: "some-styles", valueOriginal: "some-styles" },
+        { value: "nested-class", valueOriginal: "nested-class" },
+        { value: "nested-another", valueOriginal: "nested-another" }
+      ]);
     });
 
     test("it converts a file path to an array of class names with param as the name format", async () => {
@@ -21,7 +29,11 @@ describe("fileToClassNames", () => {
         nameFormat: "param"
       });
 
-      expect(result).toEqual(["some-styles", "nested-class", "nested-another"]);
+      expect(result).toEqual([
+        { value: "some-styles", valueOriginal: "some-styles" },
+        { value: "nested-class", valueOriginal: "nested-class" },
+        { value: "nested-another", valueOriginal: "nested-another" }
+      ]);
     });
 
     test("it converts a file path to an array of class names where only classes with dashes in the names are altered", async () => {
@@ -29,7 +41,11 @@ describe("fileToClassNames", () => {
         nameFormat: "dashes"
       });
 
-      expect(result).toEqual(["App", "Logo", "appHeader"]);
+      expect(result).toEqual([
+        { value: "App", valueOriginal: "App" },
+        { value: "Logo", valueOriginal: "Logo" },
+        { value: "appHeader", valueOriginal: "App-Header" }
+      ]);
     });
 
     test("it does not change class names when nameFormat is set to none", async () => {
@@ -37,7 +53,11 @@ describe("fileToClassNames", () => {
         nameFormat: "none"
       });
 
-      expect(result).toEqual(["App", "Logo", "App-Header"]);
+      expect(result).toEqual([
+        { value: "App", valueOriginal: "App" },
+        { value: "Logo", valueOriginal: "Logo" },
+        { value: "App-Header", valueOriginal: "App-Header" }
+      ]);
     });
   });
 

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -7,13 +7,16 @@ describe("classNamesToTypeDefinitions", () => {
 
   describe("named", () => {
     it("converts an array of class name strings to type definitions", () => {
-      const definition = classNamesToTypeDefinitions(["myClass", "yourClass"], {
-        watch: false,
-        ignoreInitial: false,
-        exportType: "named",
-        listDifferent: false,
-        lineEnding: "\\n"
-      });
+      const definition = classNamesToTypeDefinitions(
+        [{ value: "myClass" }, { value: "yourClass" }],
+        {
+          watch: false,
+          ignoreInitial: false,
+          exportType: "named",
+          listDifferent: false,
+          lineEnding: "\\n"
+        }
+      );
 
       expect(definition).toEqual(
         "export const myClass: string;\nexport const yourClass: string;\n"
@@ -33,13 +36,16 @@ describe("classNamesToTypeDefinitions", () => {
     });
 
     it("prints a warning if a classname is a reserved keyword and does not include it in the type definitions", () => {
-      const definition = classNamesToTypeDefinitions(["myClass", "if"], {
-        watch: false,
-        ignoreInitial: false,
-        exportType: "named",
-        listDifferent: false,
-        lineEnding: "\\n"
-      });
+      const definition = classNamesToTypeDefinitions(
+        [{ value: "myClass" }, { value: "if" }],
+        {
+          watch: false,
+          ignoreInitial: false,
+          exportType: "named",
+          listDifferent: false,
+          lineEnding: "\\n"
+        }
+      );
 
       expect(definition).toEqual("export const myClass: string;\n");
       expect(console.log).toBeCalledWith(
@@ -49,7 +55,7 @@ describe("classNamesToTypeDefinitions", () => {
 
     it("prints a warning if a classname is invalid and does not include it in the type definitions", () => {
       const definition = classNamesToTypeDefinitions(
-        ["myClass", "invalid-variable"],
+        [{ value: "myClass" }, { value: "invalid-variable" }],
         {
           watch: false,
           ignoreInitial: false,
@@ -68,13 +74,16 @@ describe("classNamesToTypeDefinitions", () => {
 
   describe("default", () => {
     it("converts an array of class name strings to type definitions", () => {
-      const definition = classNamesToTypeDefinitions(["myClass", "yourClass"], {
-        watch: false,
-        ignoreInitial: false,
-        exportType: "default",
-        listDifferent: false,
-        lineEnding: "\\n"
-      });
+      const definition = classNamesToTypeDefinitions(
+        [{ value: "myClass" }, { value: "yourClass" }],
+        {
+          watch: false,
+          ignoreInitial: false,
+          exportType: "default",
+          listDifferent: false,
+          lineEnding: "\\n"
+        }
+      );
 
       expect(definition).toEqual(
         "export interface Styles {\n  'myClass': string;\n  'yourClass': string;\n}\n\nexport type ClassNames = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n"
@@ -96,7 +105,7 @@ describe("classNamesToTypeDefinitions", () => {
 
   describe("invalid export type", () => {
     it("returns null", () => {
-      const definition = classNamesToTypeDefinitions(["myClass"], {
+      const definition = classNamesToTypeDefinitions([{ value: "myClass" }], {
         watch: false,
         ignoreInitial: false,
         exportType: "invalid" as ExportType,

--- a/__tests__/typescript/get-type-definition-path.test.ts
+++ b/__tests__/typescript/get-type-definition-path.test.ts
@@ -2,7 +2,7 @@ import { getTypeDefinitionPath } from "../../lib/typescript";
 
 describe("getTypeDefinitionPath", () => {
   it("returns the type definition path", () => {
-    const path = getTypeDefinitionPath("/some/path/style.less");
+    const path = getTypeDefinitionPath("/some/path/style.less", "default");
 
     expect(path).toEqual("/some/path/style.less.d.ts");
   });

--- a/lib/core/list-different.ts
+++ b/lib/core/list-different.ts
@@ -43,7 +43,7 @@ export const checkFile = (
         return;
       }
 
-      const path = getTypeDefinitionPath(file);
+      const path = getTypeDefinitionPath(file, options.exportType);
 
       const content = fs.readFileSync(path, { encoding: "UTF8" });
 

--- a/lib/core/write-file.ts
+++ b/lib/core/write-file.ts
@@ -26,7 +26,7 @@ export const writeFile = (
         return;
       }
 
-      const path = getTypeDefinitionPath(file);
+      const path = getTypeDefinitionPath(file, options.exportType);
 
       fs.writeFileSync(path, typeDefinition);
       options.verbose && alerts.success(`[GENERATED TYPES] ${path}`);

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -3,28 +3,31 @@ import reserved from "reserved-words";
 import { ClassNames, ClassName } from "lib/less/file-to-class-names";
 import { alerts, MainOptions } from "../core";
 
-export type ExportType = "named" | "default";
-export const EXPORT_TYPES: ExportType[] = ["named", "default"];
+export type ExportType = "named" | "values" | "default";
+export const EXPORT_TYPES: ExportType[] = ["named", "values", "default"];
 
 const classNameToNamedTypeDefinition = (className: ClassName) =>
-  `export const ${className}: string;`;
+  `export const ${className.value}: string;`;
+
+const classNameToValues = (className: ClassName) =>
+  `export const ${className.value} = "${className.valueOriginal}";`;
 
 const classNameToInterfaceKey = (className: ClassName) =>
-  `  '${className}': string;`;
+  `  '${className.value}': string;`;
 
 const isReservedKeyword = (className: ClassName) =>
-  reserved.check(className, "es5", true) ||
-  reserved.check(className, "es6", true);
+  reserved.check(className.value, "es5", true) ||
+  reserved.check(className.value, "es6", true);
 
 const isValidName = (className: ClassName) => {
   if (isReservedKeyword(className)) {
     alerts.warn(
-      `[SKIPPING] '${className}' is a reserved keyword (consider renaming or using --exportType default).`
+      `[SKIPPING] '${className.value}' is a reserved keyword (consider renaming or using --exportType default).`
     );
     return false;
-  } else if (/-/.test(className)) {
+  } else if (/-/.test(className.value)) {
     alerts.warn(
-      `[SKIPPING] '${className}' contains dashes (consider using 'camelCase' or 'dashes' for --nameFormat or using --exportType default).`
+      `[SKIPPING] '${className.value}' contains dashes (consider using 'camelCase' or 'dashes' for --nameFormat or using --exportType default).`
     );
     return false;
   }
@@ -58,6 +61,11 @@ export const classNamesToTypeDefinitions = (
         typeDefinitions = classNames
           .filter(isValidName)
           .map(classNameToNamedTypeDefinition);
+
+        // Sepearte all type definitions be a newline with a trailing newline.
+        return typeDefinitions.join(newLine) + newLine;
+      case "values":
+        typeDefinitions = classNames.filter(isValidName).map(classNameToValues);
 
         // Sepearte all type definitions be a newline with a trailing newline.
         return typeDefinitions.join(newLine) + newLine;

--- a/lib/typescript/get-type-definition-path.ts
+++ b/lib/typescript/get-type-definition-path.ts
@@ -1,7 +1,15 @@
+import { ExportType } from "./class-names-to-type-definition";
+
 /**
  * Given a file path to a LESS file, generate the corresponding type defintion
  * file path.
  *
  * @param file the LESS file path
  */
-export const getTypeDefinitionPath = (file: string): string => `${file}.d.ts`;
+export const getTypeDefinitionPath = (
+  file: string,
+  exportType: ExportType
+): string =>
+  exportType == "values"
+    ? `${file.replace(/\.less$/, "")}.const.ts`
+    : `${file}.d.ts`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-less-modules",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "TypeScript type definition generator for LESS CSS Modules",
   "main": "index.js",
   "author": "",


### PR DESCRIPTION
Added a new export type:

#### `values`

Given the following LESS (text.less):

```less
.text {
  color: blue;

  &-highlighted {
    color: yellow;
  }
}
```

The following text.const.ts file will be generated:

```typescript
export const text = "text";
export const textHighlighted = "text-highlighted";
```

In this mode, the tool is used to create .const.ts files instead of .d.ts files. This is the most optimal for compilation, because it allows to not process .less files with bundler thus significantly reducing compilation time for big projects.

Having constants in .const.ts instead of .less.d.ts gives some additional comfort on opening source files, because we have different file extensions.

1. Setup generation of .constant.ts and .css files .less on save.

For VSCode, use emeraldwalk.runonsave plugin.

Add these settings to .vscode/settings.json:

```json
	"emeraldwalk.runonsave": {
		"commands": [
			{
				"match": "\\.less$",
				"cmd": "lessc -x --js src/index.less build/index.css && tlm ${file} -e values"
			}
		]
	},
```

2. Change imports of constants:

```typescript
import * as style from "./text.const";
```

3. Remove all imports of .less files from .tsx files

4. Remove .less file handling from bundler. In case of Webpack, remove the plugin chain of .less processing: less-loader (which compiles Less to CSS), css-loader (which translates CSS into CommonJS) and MiniCssExtractPlugin.loader (which creates style nodes from JS strings).